### PR TITLE
changed visibility of variables

### DIFF
--- a/contracts/LockedPoolz.sol
+++ b/contracts/LockedPoolz.sol
@@ -26,9 +26,9 @@ contract LockedPoolz is Manageable {
     }
 
     mapping(uint256 => mapping(address=> uint256)) public Allowance;
-    mapping(uint256 => Pool) AllPoolz;
-    mapping(address => uint256[]) MyPoolz;
-    uint256 internal Index;
+    mapping(uint256 => Pool) public AllPoolz;
+    mapping(address => uint256[]) public MyPoolz;
+    uint256 public Index;
 
     modifier isTokenValid(address _Token){
         require(isTokenWhiteListed(_Token), "Need Valid ERC20 Token"); //check if _Token is ERC20

--- a/contracts/LockedPoolzData.sol
+++ b/contracts/LockedPoolzData.sol
@@ -39,34 +39,6 @@ contract LockedPoolzData is LockedControl {
         return activeIds;
     }
 
-    function GetPoolData(uint256 _id)
-        public
-        view
-        isPoolValid(_id)
-        returns (
-            uint256,
-            uint256,
-            uint256,
-            uint256,
-            address,
-            address
-        )
-    {
-        Pool storage pool = AllPoolz[_id];
-        require(
-            pool.Owner == msg.sender || Allowance[_id][msg.sender] > 0,
-            "Private Information"
-        );
-        return (
-            pool.StartTime,
-            pool.FinishTime,
-            pool.StartAmount,
-            pool.DebitedAmount,
-            pool.Owner,
-            pool.Token
-        );
-    }
-
     function GetMyPoolsIdByToken(address[] memory _tokens)
         public
         view

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poolz-locked-deal-v2",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "truffle-config.js",
   "directories": {
     "test": "test"

--- a/test/2_CreatePool.js
+++ b/test/2_CreatePool.js
@@ -23,7 +23,7 @@ contract('Create Pool', accounts => {
         const owner = accounts[1]
         const tx = await instance.CreateNewPool(Token.address, startTime, finishTime, allow, owner, { from: fromAddress })
         const poolId = tx.logs[1].args.PoolId
-        const result = await instance.GetPoolData(poolId, { from: owner })
+        const result = await instance.AllPoolz(poolId, { from: owner })
         assert.equal(result[4], owner)
     })
 

--- a/test/4_Access.js
+++ b/test/4_Access.js
@@ -32,7 +32,7 @@ contract('Access to Locked Deal', accounts => {
         const newOwner = accounts[8]
         poolId = 1
         await instance.TransferPoolOwnership(poolId, newOwner, { from: owner })
-        const pool = await instance.GetPoolData(poolId, { from: newOwner })
+        const pool = await instance.AllPoolz(poolId, { from: newOwner })
         const newPools = await instance.GetAllMyPoolsId({ from: newOwner })
         assert.equal(newPools[0].toString(), poolId)
         assert.equal(pool[4], newOwner)
@@ -48,9 +48,9 @@ contract('Access to Locked Deal', accounts => {
         const pid = tx.logs[0].args.PoolId
         const pAmount = tx.logs[0].args.StartAmount
         assert.equal(amount, pAmount)
-        const pool = await instance.GetPoolData(poolId, { from: owner })
+        const pool = await instance.AllPoolz(poolId, { from: owner })
         assert.equal(pool[2], allow)
-        const newPool = await instance.GetPoolData(pid, { from: owner })
+        const newPool = await instance.AllPoolz(pid, { from: owner })
         assert.equal(newPool[2], amount)
     })
 
@@ -60,9 +60,9 @@ contract('Access to Locked Deal', accounts => {
         const approvedAddress = accounts[7]
         const tx = await instance.SplitPoolAmount(poolId, amount, approvedAddress, { from: owner })
         const pid = tx.logs[0].args.PoolId
-        const pool = await instance.GetPoolData(poolId, { from: owner })
+        const pool = await instance.AllPoolz(poolId, { from: owner })
         assert.equal(pool[2], allow)
-        const newPool = await instance.GetPoolData(pid, { from: approvedAddress })
+        const newPool = await instance.AllPoolz(pid, { from: approvedAddress })
         assert.equal(newPool[2], amount)
     })
 
@@ -85,8 +85,8 @@ contract('Access to Locked Deal', accounts => {
         it('giving approval', async () => {
             await instance.ApproveAllowance(poolId, approvalAmount, spender, { from: owner })
             const amount = await instance.GetPoolAllowance(poolId, spender)
-            const dataOwner = await instance.GetPoolData(poolId, { from: owner })
-            const dataSpender = await instance.GetPoolData(poolId, { from: spender })
+            const dataOwner = await instance.AllPoolz(poolId, { from: owner })
+            const dataSpender = await instance.AllPoolz(poolId, { from: spender })
             assert.equal(approvalAmount, amount)
             assert.deepEqual(dataOwner, dataSpender)
         })
@@ -95,7 +95,7 @@ contract('Access to Locked Deal', accounts => {
             const newOwner = accounts[2]
             const tx = await instance.SplitPoolAmountFrom(poolId, approvalAmount, newOwner, { from: spender })
             const newPoolId = tx.logs[0].args.PoolId
-            const data = await instance.GetPoolData(newPoolId, { from: newOwner })
+            const data = await instance.AllPoolz(newPoolId, { from: newOwner })
             assert.equal(approvalAmount, data[2])
 
         })
@@ -120,7 +120,7 @@ contract('Access to Locked Deal', accounts => {
         })
 
         it('Fail to split pool when balance is not enough', async () => {
-            const data = await instance.GetPoolData(poolId, { from: owner })
+            const data = await instance.AllPoolz(poolId, { from: owner })
             const amount = data[1] + 1
             await truffleAssert.reverts(instance.SplitPoolAmount(poolId, amount, owner, { from: owner }), "Not Enough Amount Balance")
         })

--- a/test/7_Withdraw.js
+++ b/test/7_Withdraw.js
@@ -25,7 +25,7 @@ contract('Withdraw', (accounts) => {
     })
 
     it('get withdrawable amount', async () => {
-        const data = await instance.GetPoolData(poolId, { from: investor })
+        const data = await instance.AllPoolz(poolId, { from: investor })
         const startAmount = data[2].toString()
         const debitedAmount = data[3].toString()
         const totalPoolDuration = data[1] - data[0]
@@ -53,7 +53,7 @@ contract('Withdraw', (accounts) => {
         const tx = await instance.CreateNewPool(Token.address, startTime, finishTime, allow, investor, { from: fromAddress })
         poolId = tx.logs[1].args.PoolId.toString()
         MyPoolz.push(poolId)
-        const data = await instance.GetPoolData(poolId, { from: investor })
+        const data = await instance.AllPoolz(poolId, { from: investor })
         const startAmount = data[2].toString()
         const debitedAmount = data[3].toString()
         date.setDate(date.getDate() + 2)


### PR DESCRIPTION
Closes #48 
AllPoolz will return `(StartTime uint256, FinishTime uint256, StartAmount uint256, DebitedAmount uint256, Owner address, Token address)`
I didn't remove GetAllMyPoolsId() because the mapping getter (address => uint256[]) returns uint256 instead of uint256[]
This mechanism exists to avoid high gas costs when returning an entire array  